### PR TITLE
Initialize gcounter rate to 0.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* Tue Jun 18 2019 David Hull <david.hull@openx.com> 6.12.1
+- Initialize gcounter rate to 0.
+
 * Tue Jun 4 2019 David Hull <david.hull@openx.com> 6.12.0
 - Add gcounter type, a counter which emits values like a gauge.
 

--- a/src/mondemand_statdb.erl
+++ b/src/mondemand_statdb.erl
@@ -234,7 +234,7 @@ try_update_counter (InternalKey =
 
 
 -record(md_gcounter,
-        { rate :: integer() | 'undefined',
+        { rate = 0 :: integer(),
           key :: #mdkey{},                      % Must be in same position as #md_metric.key.
           value :: non_neg_integer(),           % Must be in same position as #md_metric.value.
           previous_value :: non_neg_integer(),
@@ -1129,9 +1129,10 @@ config_perf_test_ () ->
        fun () ->
          ?assertEqual (#md_metric.key, #md_gcounter.key),
          ?assertEqual (#md_metric.value, #md_gcounter.value),
+         ?assertEqual (undefined, fetch_gcounter(my_prog1, gctr)),
          ?assertEqual ({ok, 1}, gincrement (my_prog1, gctr, [], 1)),
          ?assertEqual ({ok, 4}, gincrement (my_prog1, gctr, [], 3)),
-         ?assertEqual (undefined, fetch_gcounter(my_prog1, gctr)),
+         ?assertEqual (0, fetch_gcounter(my_prog1, gctr)),
          Key = calculate_key(my_prog1, [], gcounter, gctr),
          finalize_metric(Key, ?STATS_TABLE),
          ?assertMatch (V when is_number(V) andalso V >= 4,


### PR DESCRIPTION
This fixes a crash when attempting to emit metrics to lwes when the rate is undefined. I'm not really sure how the crash happens, because if finalize_metric is called then the rate should be set to an integer value.

The stack dump was:
```
{badarg,[
         {lwes_event,write,2,[{file,"/var/lib/jenkins-agent/workspace/ssrtb-server_master/_build/default/lib/lwes/src/lwes_event.erl"},{line,623}]},
         {lwes_event,write_attrs,2,[{file,"/var/lib/jenkins-agent/workspace/ssrtb-server_master/_build/default/lib/lwes/src/lwes_event.erl"},{line,461}]},
         {lwes_event,to_iolist,1,[{file,"/var/lib/jenkins-agent/workspace/ssrtb-server_master/_build/default/lib/lwes/src/lwes_event.erl"},{line,250}]},
         {lwes_event,to_binary,1,[{file,"/var/lib/jenkins-agent/workspace/ssrtb-server_master/_build/default/lib/lwes/src/lwes_event.erl"},{line,238}]},
         {mondemand,send_event,1,[{file,"/var/lib/jenkins-agent/workspace/ssrtb-server_master/_build/default/lib/mondemand/src/mondemand.erl"},{line,501}]},
         {mondemand,flush_one_stat,2,[{file,"/var/lib/jenkins-agent/workspace/ssrtb-server_master/_build/default/lib/mondemand/src/mondemand.erl"},{line,507}]},
         {mondemand_statdb,flush,3,[{file,"/var/lib/jenkins-agent/workspace/ssrtb-server_master/_build/default/lib/mondemand/src/mondemand_statdb.erl"},{line,841}]},
         {mondemand,flush,1,[{file,"/var/lib/jenkins-agent/workspace/ssrtb-server_master/_build/default/lib/mondemand/src/mondemand.erl"},{line,334}]}]}
```