### PR TITLE
Initial Stab at prometheus exporter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+* Mon Jul 01 2019 Anthony Molinaro <anthony.molinaro@openx.com> 7.0.0
+- Added extra field to #md_metric record for description (NOT BACKWARD
+COMPATIBLE if using this record)
+- Moved many functions from mondemand_statdb module to mondemand module
+- Added optional http server with prometheus exporter
+
 * Tue Jun 18 2019 Anthony Molinaro <anthony.molinaro@openx.com> 6.12.1
 - rename some confusing names
 - get mondemand_statdb:config() to print out parts of md_config table

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ clean:
 	if test -d _build; then $(REBAR3) clean; fi
 
 maintainer-clean: clean
-	rm -rf _build
+	rm -rf _build deps ebin tmp _checkouts/*/ebin
 
 .PHONY:  all test name version clean maintainer-clean

--- a/include/mondemand.hrl
+++ b/include/mondemand.hrl
@@ -53,7 +53,8 @@
 -record (md_metric, { type,
                       key,
                       value,
-                      description = ""
+                      description = "",
+                      collect_time = undefined
                     }).
 -record (md_statset, { count,
                        sum,

--- a/include/mondemand.hrl
+++ b/include/mondemand.hrl
@@ -53,7 +53,7 @@
 -record (md_metric, { type,
                       key,
                       value,
-                      description
+                      description = ""
                     }).
 -record (md_statset, { count,
                        sum,

--- a/include/mondemand.hrl
+++ b/include/mondemand.hrl
@@ -52,7 +52,8 @@
                        }).
 -record (md_metric, { type,
                       key,
-                      value
+                      value,
+                      description
                     }).
 -record (md_statset, { count,
                        sum,

--- a/mondemand_dev.config
+++ b/mondemand_dev.config
@@ -4,9 +4,10 @@
      { lwes_channel, { 1, [ { "127.0.0.1", 21512 } ] } }
 %     { lwes_channel, { 1, [ { "127.0.0.1", 20602 } ] } },
 %     { lwes_channel, { 2, [{"127.0.0.1",20602}, {"172.16.107.128", 20602}] } },
-%      { config_file, "mondemand.conf" },
-%     , { vmstats, [ { program_id, mondemand_erlang } ] }
-%     { send_interval, 5 }
+%    , { config_file, "mondemand.conf" },
+     , { vmstats, [ { program_id, erlang_vm } ] }
+%    , { lwes_stats_disabled, true }
+%    , { send_interval, 5 }
      , { httpd, [ {port, 8082} ] }
     ]
   }

--- a/mondemand_dev.config
+++ b/mondemand_dev.config
@@ -7,6 +7,7 @@
 %      { config_file, "mondemand.conf" },
 %     , { vmstats, [ { program_id, mondemand_erlang } ] }
 %     { send_interval, 5 }
+     , { httpd, [ {port, 8082} ] }
     ]
   }
 ].

--- a/rebar.config
+++ b/rebar.config
@@ -3,11 +3,9 @@
 
 %% enable coverage output when running eunit
 { cover_enabled, true }.
-{ cover_export_enabled, true }.
 { cover_opts, [verbose] }.
-{ cover_print_enabled, true }.
 
-%% always include debug info so AST is included in beams
+%% always include debug_info so AST is included in beams
 {erl_opts,
   [
     debug_info,
@@ -15,11 +13,13 @@
   ]
 }.
 
+{dialyzer, [ {warnings, [no_unused]} ]}.
+
 {clean_files, ["ebin", "doc"]}.
 
 {deps,
   [
     { lwes, {git, "git://github.com/lwes/lwes-erlang.git", {tag, "5.0.0"}} },
-    { parse_trans, {git, "git://github.com/uwiger/parse_trans.git", {tag, "3.2.0"} } }
+    { parse_trans, {git, "git://github.com/uwiger/parse_trans.git", {tag, "3.3.0"} } }
   ]
 }.

--- a/src/mondemand_config.erl
+++ b/src/mondemand_config.erl
@@ -28,6 +28,10 @@
            max_metrics/0,
            parse_config/1,
            get_http_config/0,
+           httpd_enabled/0,
+           httpd_port/0,
+           httpd_address/0,
+           httpd_metrics_endpoint/0,
            vmstats_enabled/0,
            vmstats_prog_id/0,
            vmstats_context/0,
@@ -300,6 +304,21 @@ get_http_config () ->
       end
   end.
 
+httpd_enabled () ->
+  case application:get_env (mondemand, httpd) of
+    {ok, L} when is_list (L) -> true;
+    _ -> false
+  end.
+
+httpd_port () ->
+  get_config_with_default (httpd, port, 31337).
+
+httpd_address () ->
+  get_config_with_default (httpd, bind_address, "0.0.0.0").
+
+httpd_metrics_endpoint () ->
+  get_config_with_default (httpd, metrics_endpoint, "/md/metrics").
+
 vmstats_enabled () ->
   case application:get_env (mondemand, vmstats) of
     {ok, L} when is_list (L) ->
@@ -312,11 +331,11 @@ vmstats_enabled () ->
   end.
 
 vmstats_prog_id () ->
-  vmstats_config (program_id, undefined).
+  get_config_with_default (vmstats, program_id, undefined).
 vmstats_context () ->
-  vmstats_config (context, []).
+  get_config_with_default (vmstats, context, []).
 vmstats_disable_scheduler_wall_time () ->
-  vmstats_config (disable_scheduler_wall_time, false).
+  get_config_with_default (vmstats, disable_scheduler_wall_time, false).
 
 vmstats_legacy_workaround () ->
   case application:get_env(mondemand,r15b_workaround) of
@@ -324,8 +343,8 @@ vmstats_legacy_workaround () ->
     _ -> false
   end.
 
-vmstats_config (K, Default) ->
-  case application:get_env (mondemand, vmstats) of
+get_config_with_default (M, K, Default) ->
+  case application:get_env (mondemand, M) of
     {ok, L} when is_list (L) ->
       case proplists:get_value (K, L) of
         undefined -> Default;

--- a/src/mondemand_httpd.erl
+++ b/src/mondemand_httpd.erl
@@ -1,0 +1,22 @@
+-module(mondemand_httpd).
+
+-export([do/1]).
+
+-include_lib("inets/include/httpd.hrl").
+
+-define(SERVER_NAME, "Mondemand metrics.").
+
+do(#mod { method = Method, request_uri = URI }) ->
+  case URI =:= mondemand_config:httpd_metrics_endpoint()
+       andalso Method =:= "GET" of
+    true ->
+      Body = mondemand:export_as_prometheus(),
+      ContentLength = integer_to_list(iolist_size(Body)),
+      RespHeaders = [{"accept","text/plain"},
+                     {code, 200},
+                     {content_type, "text/plain"},
+                     {content_length,ContentLength}],
+      {break,[{response, {response, RespHeaders, [Body]}}]};
+    false ->
+      {break,[{response, {404,""}}]}
+  end.

--- a/src/mondemand_statdb.erl
+++ b/src/mondemand_statdb.erl
@@ -42,59 +42,43 @@
 
 %% API
 -export([ start_link/0,
-          get_state/0,
 
           % counter functions
-          create_counter/2,
-          create_counter/3,
-          create_counter/4,
           create_counter/5,
-          increment/2,
-          increment/3,
-          increment/4,
-          fetch_counter/2,
+          increment_counter/4,
           fetch_counter/3,
-          remove_counter/2,
           remove_counter/3,
 
           % gcounter functions
-          create_gcounter/4,
-          gincrement/4,
-          fetch_gcounter/2,
+          create_gcounter/5,
+          increment_gcounter/4,
           fetch_gcounter/3,
+          remove_gcounter/3,
 
           % gauge functions
-          create_gauge/2,
-          create_gauge/3,
-          create_gauge/4,
           create_gauge/5,
-          set/3,
-          set/4,
-          fetch_gauge/2,
+          set_gauge/4,
           fetch_gauge/3,
-          remove_gauge/2,
           remove_gauge/3,
 
           % sample set functions
-          create_sample_set/2,
-          create_sample_set/3,
-          create_sample_set/4,
-          create_sample_set/5,
           create_sample_set/6,
-          add_sample/3,
           add_sample/4,
-          fetch_sample_set/2,
           fetch_sample_set/3,
           fetch_sample_set/4,
-          remove_sample_set/2,
           remove_sample_set/3,
-
           all_sample_set_stats/0,
 
+          % mapping functions, used to iterate over all stats, when now is used
+          % the current live dbs for all types are used, when then functions
+          % are used the db for however many minutes ago is used.
           map_now/1,
+          map_now/2,
           map_then/2,
+          map_then/3,
           map/4,
 
+          description/1,
           flush/3,
           config/0,
           all/0,
@@ -146,46 +130,25 @@
 start_link() ->
   gen_server:start_link ({local, ?MODULE}, ?MODULE, [], []).
 
-get_state() ->
-  gen_server:call (?MODULE, get_state).
-
-create_counter (ProgId, Key) ->
-  create_counter (ProgId, Key, [], "", 0).
-create_counter (ProgId, Key, Description) ->
-  create_counter (ProgId, Key, [], Description, 0).
-create_counter (ProgId, Key, Context, Description) ->
-  create_counter (ProgId, Key, Context, Description, 0).
-create_counter (ProgId, Key, Context, Description, Amount)
-  when is_integer (Amount), is_list (Context) ->
+create_counter (ProgId, Key, Context, Description, InitialAmount)
+  when is_integer (InitialAmount), is_list (Context) ->
   InternalKey = calculate_key (ProgId, Context, counter, Key),
   add_new_config (InternalKey, Description),
   case ets:insert_new (?STATS_TABLE,
-                       #md_metric {key = InternalKey, value = Amount}) of
+                       #md_metric {key = InternalKey, value = InitialAmount}) of
     true -> ok;
     false -> {error, already_created}
   end.
 
-increment (ProgId, Key) ->
-  increment (ProgId, Key, [], 1).
-increment (ProgId, Key, Amount)
-  when is_integer (Amount) ->
-  increment (ProgId, Key, [], Amount);
-increment (ProgId, Key, Context)
-  when is_list (Context) ->
-  increment (ProgId, Key, Context, 1).
-increment (ProgId, Key, Context, Amount)
+increment_counter (ProgId, Key, Context, Amount)
   when is_integer (Amount), is_list (Context) ->
   InternalKey = calculate_key (ProgId, Context, counter, Key),
   try_update_counter (InternalKey, Amount).
 
-fetch_counter (ProgId, Key) ->
-  fetch_counter (ProgId, Key, []).
 fetch_counter (ProgId, Key, Context) ->
   InternalKey = calculate_key (ProgId, Context, counter, Key),
   return_if_exists (InternalKey, ?STATS_TABLE).
 
-remove_counter (ProgId, Key) ->
-  remove_counter (ProgId, Key, []).
 remove_counter (ProgId, Key, Context) ->
   InternalKey = calculate_key (ProgId, Context, counter, Key),
   remove_metric (InternalKey, ?STATS_TABLE).
@@ -240,14 +203,15 @@ try_update_counter (InternalKey =
           previous_value :: non_neg_integer(),
           previous_time :: integer() }).
 
-create_gcounter (ProgId, Key, Context, Amount)
-  when is_list(Context), is_integer(Amount) ->
-  create_gcounter (calculate_key (ProgId, Context, gcounter, Key), Amount).
+create_gcounter (ProgId, Key, Context, Description, InitialAmount)
+  when is_list(Context), is_integer(InitialAmount) ->
+  InternalKey = calculate_key (ProgId, Context, gcounter, Key),
+  create_gcounter_internal (InternalKey, Description, InitialAmount).
 
-create_gcounter (InternalKey, Amount) ->
-  add_new_config (InternalKey, ""),
+create_gcounter_internal (InternalKey, Description, InitialAmount) ->
+  add_new_config (InternalKey, Description),
   NewGCounter = #md_gcounter{ key = InternalKey,
-                              value = Amount,
+                              value = InitialAmount,
                               previous_value = 0,
                               previous_time = erlang:monotonic_time() },
   case ets:insert_new (?STATS_TABLE, NewGCounter) of
@@ -255,7 +219,7 @@ create_gcounter (InternalKey, Amount) ->
     false -> {error, already_created}
   end.
 
-gincrement (ProgId, Key, Context, Amount)
+increment_gcounter (ProgId, Key, Context, Amount)
   when is_integer (Amount), is_list (Context) ->
   InternalKey = calculate_key (ProgId, Context, gcounter, Key),
   update_gcounter (InternalKey, Amount).
@@ -270,37 +234,31 @@ update_gcounter (InternalKey, Amount) ->
     %% default object to the original ets:update_counter call so that we can
     %% create the config row.
     error:badarg ->
-      case create_gcounter (InternalKey, Amount) of
+      case create_gcounter_internal (InternalKey, "", Amount) of
         ok                       -> {ok, Amount};
         {error, already_created} -> {ok, update_counter (InternalKey, Amount)}
       end
   end.
 
-fetch_gcounter (ProgId, Key) ->
-  fetch_gcounter (ProgId, Key, []).
 fetch_gcounter (ProgId, Key, Context) ->
   InternalKey = calculate_key (ProgId, Context, gcounter, Key),
   return_if_exists (InternalKey, ?STATS_TABLE).
 
+remove_gcounter (ProgId, Key, Context) ->
+  InternalKey = calculate_key (ProgId, Context, gcounter, Key),
+  remove_metric (InternalKey, ?STATS_TABLE).
 
-create_gauge (ProgId, Key) ->
-  create_gauge (ProgId, Key, [], "", 0).
-create_gauge (ProgId, Key, Description) ->
-  create_gauge (ProgId, Key, [], Description, 0).
-create_gauge (ProgId, Key, Context, Description) ->
-  create_gauge (ProgId, Key, Context, Description, 0).
-create_gauge (ProgId, Key, Context, Description, Amount) ->
+create_gauge (ProgId, Key, Context, Description, InitialAmount)
+  when is_integer (InitialAmount), is_list (Context) ->
   InternalKey = calculate_key (ProgId, Context, gauge, Key),
   add_new_config (InternalKey, Description),
   case ets:insert_new (?STATS_TABLE,
-                       #md_metric {key = InternalKey, value = Amount}) of
+                       #md_metric {key = InternalKey, value = InitialAmount}) of
     true -> ok;
     false -> {error, already_created}
   end.
 
-set (ProgId, Key, Amount) ->
-  set (ProgId, Key, [], Amount).
-set (ProgId, Key, Context, Amount) ->
+set_gauge (ProgId, Key, Context, Amount) ->
   InternalKey = calculate_key (ProgId, Context, gauge, Key),
 
   % if we would overflow a gauge, instead of going negative just leave it
@@ -328,14 +286,10 @@ set (ProgId, Key, Context, Amount) ->
       end
   end.
 
-fetch_gauge (ProgId, Key) ->
-  fetch_gauge (ProgId, Key, []).
 fetch_gauge (ProgId, Key, Context) ->
   InternalKey = calculate_key (ProgId, Context, gauge, Key),
   return_if_exists (InternalKey, ?STATS_TABLE).
 
-remove_gauge (ProgId, Key) ->
-  remove_gauge (ProgId, Key, []).
 remove_gauge (ProgId, Key, Context) ->
   InternalKey = calculate_key (ProgId, Context, gauge, Key),
   remove_metric (InternalKey, ?STATS_TABLE).
@@ -364,22 +318,9 @@ try_update_gauge (InternalKey =
       end
   end.
 
-create_sample_set (ProgId, Key) ->
-  create_sample_set (ProgId, Key, [], "",
-                     mondemand_config:default_max_sample_size(),
-                     mondemand_config:default_stats()).
-create_sample_set (ProgId, Key, Description) ->
-  create_sample_set (ProgId, Key, [], Description,
-                     mondemand_config:default_max_sample_size(),
-                     mondemand_config:default_stats()).
-create_sample_set (ProgId, Key, Context, Description) ->
-  create_sample_set (ProgId, Key, Context, Description,
-                     mondemand_config:default_max_sample_size(),
-                     mondemand_config:default_stats()).
-create_sample_set (ProgId, Key, Context, Description, Max) ->
-  create_sample_set (ProgId, Key, Context, Description,
-                     Max,
-                     mondemand_config:default_stats()).
+create_sample_set (ProgId, Key, Context, Description, Max, all) ->
+  create_sample_set (ProgId, Key, Context, Description, Max,
+                     all_sample_set_stats());
 create_sample_set (ProgId, Key, Context, Description, Max, Stats) ->
   InternalKey = calculate_key (ProgId, Context, statset, Key),
   create_sample_set_internal (minute_tab (mondemand_util:current_minute()),
@@ -429,9 +370,6 @@ try_update_sampleset (CurrentMinuteStatsSetTable, InternalKey, Value) ->
       [M, UC]
   end.
 
-add_sample (ProgId, Key, Value) ->
-  add_sample (ProgId, Key, [], Value).
-
 % this implements reservoir sampling of values
 %   http://en.wikipedia.org/wiki/Reservoir_sampling
 % in an ets table
@@ -473,9 +411,6 @@ add_sample (ProgId, Key, Context, Value) ->
     I -> ets:update_element (Tid, InternalKey, {?STATSET_SUM_INDEX+I,Value})
   end.
 
-fetch_sample_set (ProgId, Key) ->
-  fetch_sample_set (ProgId, Key, []).
-
 fetch_sample_set (ProgId, Key, Context) ->
   fetch_sample_set (ProgId, Key, Context, mondemand_util:current_minute()).
 
@@ -484,8 +419,6 @@ fetch_sample_set (ProgId, Key, Context, Minute) ->
   CurrentMinuteStatsSetTable= minute_tab (Minute),
   return_if_exists (InternalKey, CurrentMinuteStatsSetTable).
 
-remove_sample_set (ProgId, Key) ->
-  remove_sample_set (ProgId, Key, []).
 remove_sample_set (ProgId, Key, Context) ->
   InternalKey = calculate_key (ProgId, Context, statset, Key),
   CurrentMinuteStatsSetTable = minute_tab (mondemand_util:current_minute()),
@@ -516,6 +449,12 @@ lookup_default_config () ->
   case ets:lookup (?CONFIG_TABLE, '$default_config') of
     [C = #config {}] -> C;
     [] -> undefined
+  end.
+
+description(InternalKey) ->
+  case ets:lookup (?CONFIG_TABLE, InternalKey) of
+    [] -> "";
+    [#config { description = D}] -> D
   end.
 
 add_new_config (Key, Description) ->
@@ -557,16 +496,20 @@ type_to_single_char (gcounter) -> <<"r">>;
 type_to_single_char (statset) -> <<"s">>.
 
 map_now (Function) ->
-  CurrentMinuteMillis = mondemand_util:current(),
-  StatsSetTable = minute_tab (mondemand_util:current_minute()),
-  map (Function, ok, CurrentMinuteMillis, StatsSetTable).
+  map_now (Function, ok).
+
+map_now (Function, InitialState) ->
+  map_then (Function, InitialState, 0).
 
 map_then (Function, Ago) ->
+  map_then (Function, ok, Ago).
+
+map_then (Function, InitialState, Ago) ->
   CurrentMinuteMillis = mondemand_util:current(),
   PreviousMinuteMillis = CurrentMinuteMillis - 60000 * Ago,
   PreviousMinute = minutes_ago (mondemand_util:current_minute(), Ago),
   StatsSetTable = minute_tab (PreviousMinute),
-  map (Function, ok, PreviousMinuteMillis, StatsSetTable).
+  map (Function, InitialState, PreviousMinuteMillis, StatsSetTable).
 
 % I want to iterate over the config table, collapsing all metrics for a
 % particular program id and context into a group so they can all be processed
@@ -665,33 +608,40 @@ lookup_metric (InternalKey = #mdkey {type = Type, key = Key},
                CurrentMinuteStatsSetTable) ->
   case Type of
     I when I =:= counter; I =:= gauge; I =:= gcounter ->
+      Description = description(InternalKey),
       case ets:lookup (?STATS_TABLE, InternalKey) of
         [] ->
           #md_metric { key = mondemand_util:binaryify (Key),
                        type = I,
-                       value = 0 };
+                       value = 0,
+                       description = Description };
         [#md_metric {value = V}] ->
           #md_metric { key = mondemand_util:binaryify (Key),
                        type = I,
-                       value = V };
+                       value = V,
+                       description = Description };
         [#md_gcounter {rate = V}] ->
           #md_metric { key = mondemand_util:binaryify (Key),
                        type = gauge,
-                       value = V }
+                       value = V,
+                       description = Description }
       end;
     I when I =:= statset ->
-      #config { statistics = Stats } = lookup_config (InternalKey),
+      #config { statistics = Stats, description = Description }
+        = lookup_config (InternalKey),
       case ets:lookup (CurrentMinuteStatsSetTable, InternalKey) of
         [] ->
           % special case, for filling out an empty statset
           #md_metric { key = mondemand_util:binaryify (Key),
                        type = I,
-                       value = statset (0, 0, 0, 0, [], Stats)
+                       value = statset (0, 0, 0, 0, [], Stats),
+                       description = Description
                      };
         [Entry] ->
           #md_metric { key = mondemand_util:binaryify (Key),
                        type = I,
-                       value = ets_to_statset (Entry, Stats)
+                       value = ets_to_statset (Entry, Stats),
+                       description = Description
                      }
       end
   end.
@@ -799,8 +749,6 @@ init([]) ->
                          ]),
   {ok, #state {}}.
 
-handle_call (get_state, _From, State) ->
-  {reply, State, State};
 handle_call (_Request, _From, State) ->
   {reply, ok, State}.
 
@@ -1096,112 +1044,114 @@ config_perf_test_ () ->
     fun cleanup/1,
     [
       % tests using create_counter first
-      ?_assertEqual (undefined, fetch_counter (my_prog1, my_metric1)),
-      ?_assertEqual (ok, create_counter (my_prog1, my_metric1)),
-      ?_assertEqual ({error, already_created}, create_counter (my_prog1, my_metric1)),
-      ?_assertEqual (0, fetch_counter (my_prog1, my_metric1)),
-      ?_assertEqual ({ok,1}, increment (my_prog1, my_metric1)),
-      ?_assertEqual (1, fetch_counter (my_prog1, my_metric1)),
-      ?_assertEqual ({ok,2}, increment (my_prog1, my_metric1)),
-      ?_assertEqual ({ok,3}, increment (my_prog1, my_metric1)),
-      ?_assertEqual ({ok,4}, increment (my_prog1, my_metric1)),
-      ?_assertEqual (4, fetch_counter (my_prog1, my_metric1)),
-      ?_assertEqual (true, remove_counter (my_prog1, my_metric1)),
-      ?_assertEqual (undefined, fetch_counter (my_prog1, my_metric1)),
+      ?_assertEqual (undefined, fetch_counter (my_prog1, my_metric1,[])),
+      ?_assertEqual (ok, create_counter (my_prog1, my_metric1,[],"",0)),
+      ?_assertEqual ({error, already_created}, create_counter (my_prog1, my_metric1,[],"",0)),
+      ?_assertEqual (0, fetch_counter (my_prog1, my_metric1,[])),
+      ?_assertEqual ({ok,1}, increment_counter (my_prog1, my_metric1,[],1)),
+      ?_assertEqual (1, fetch_counter (my_prog1, my_metric1,[])),
+      ?_assertEqual ({ok,2}, increment_counter (my_prog1, my_metric1,[],1)),
+      ?_assertEqual ({ok,3}, increment_counter (my_prog1, my_metric1,[],1)),
+      ?_assertEqual ({ok,4}, increment_counter (my_prog1, my_metric1,[],1)),
+      ?_assertEqual (4, fetch_counter (my_prog1, my_metric1,[])),
+      ?_assertEqual (true, remove_counter (my_prog1, my_metric1,[])),
+      ?_assertEqual (undefined, fetch_counter (my_prog1, my_metric1,[])),
 
       % test creation with descriptions
-      ?_assertEqual (ok, create_counter (my_prog1, my_metric2, "with description")),
-      ?_assertEqual ({ok,1}, increment (my_prog1, my_metric2)),
-      ?_assertEqual (1, fetch_counter (my_prog1, my_metric2)),
-      ?_assertEqual (true, remove_counter (my_prog1, my_metric2)),
-      ?_assertEqual (undefined, fetch_counter (my_prog1, my_metric2)),
+      ?_assertEqual (ok, create_counter (my_prog1, my_metric2, [], "with description", 0)),
+      ?_assertEqual ({ok,1}, increment_counter (my_prog1, my_metric2,[],1)),
+      ?_assertEqual (1, fetch_counter (my_prog1, my_metric2,[])),
+      ?_assertEqual (true, remove_counter (my_prog1, my_metric2,[])),
+      ?_assertEqual (undefined, fetch_counter (my_prog1, my_metric2,[])),
 
       % test with contexts and descriptions
-      ?_assertEqual (ok, create_counter (my_prog1, my_metric3, [{foo,bar}], "with context")),
-      ?_assertEqual ({ok,1}, increment (my_prog1, my_metric3,[{foo,bar}])),
+      ?_assertEqual (ok, create_counter (my_prog1, my_metric3, [{foo,bar}], "with context",0)),
+      ?_assertEqual ({ok,1}, increment_counter (my_prog1, my_metric3,[{foo,bar}],1)),
       ?_assertEqual (1, fetch_counter (my_prog1, my_metric3,[{foo,bar}])),
       ?_assertEqual (true, remove_counter (my_prog1, my_metric3,[{foo,bar}])),
       ?_assertEqual (undefined, fetch_counter (my_prog1, my_metric3,[{foo,bar}])),
 
       % test using automatic creation of counters
-      ?_assertEqual (undefined, fetch_counter (my_prog1, my_metric1)),
-      ?_assertEqual ({ok,1}, increment (my_prog1, my_metric1)),
-      ?_assertEqual (1, fetch_counter (my_prog1, my_metric1)),
-      ?_assertEqual (true, remove_counter (my_prog1, my_metric1)),
-      ?_assertEqual (undefined, fetch_counter (my_prog1, my_metric1)),
+      ?_assertEqual (undefined, fetch_counter (my_prog1, my_metric1,[])),
+      ?_assertEqual ({ok,1}, increment_counter (my_prog1, my_metric1,[],1)),
+      ?_assertEqual (1, fetch_counter (my_prog1, my_metric1,[])),
+      ?_assertEqual (true, remove_counter (my_prog1, my_metric1,[])),
+      ?_assertEqual (undefined, fetch_counter (my_prog1, my_metric1,[])),
 
       {"counter wrapping",
        fun () ->
-         ?assertEqual ({ok, ?MD_STATS_MAX_METRIC_VALUE - 80}, increment (my_prog1, wrapctr, ?MD_STATS_MAX_METRIC_VALUE - 80)),
-         ?assertEqual ({ok, ?MD_STATS_MAX_METRIC_VALUE - 1}, increment (my_prog1, wrapctr, 79)),
-         ?assertEqual ({ok, ?MD_STATS_MAX_METRIC_VALUE}, increment (my_prog1, wrapctr, 1)),
-         ?assertEqual ({ok, 0}, increment (my_prog1, wrapctr, 1)),
-         ?assertEqual ({ok, ?MD_STATS_MAX_METRIC_VALUE - 10}, increment (my_prog1, wrapctr, ?MD_STATS_MAX_METRIC_VALUE - 10)),
-         ?assertEqual ({ok, 3}, increment (my_prog1, wrapctr, 14)),
-         ?assertEqual ({ok, 0}, increment (my_prog1, wrapctr, -3)),
-         ?assertEqual ({ok, ?MD_STATS_MIN_METRIC_VALUE}, increment (my_prog1, wrapctr, ?MD_STATS_MIN_METRIC_VALUE)),
-         ?assertEqual ({ok, 0}, increment (my_prog1, wrapctr, -1)),
+         ?assertEqual ({ok, ?MD_STATS_MAX_METRIC_VALUE - 80}, increment_counter (my_prog1, wrapctr, [], ?MD_STATS_MAX_METRIC_VALUE - 80)),
+         ?assertEqual ({ok, ?MD_STATS_MAX_METRIC_VALUE - 1}, increment_counter (my_prog1, wrapctr, [], 79)),
+         ?assertEqual ({ok, ?MD_STATS_MAX_METRIC_VALUE}, increment_counter (my_prog1, wrapctr, [], 1)),
+         ?assertEqual ({ok, 0}, increment_counter (my_prog1, wrapctr, [], 1)),
+         ?assertEqual ({ok, ?MD_STATS_MAX_METRIC_VALUE - 10}, increment_counter (my_prog1, wrapctr, [], ?MD_STATS_MAX_METRIC_VALUE - 10)),
+         ?assertEqual ({ok, 3}, increment_counter (my_prog1, wrapctr, [], 14)),
+         ?assertEqual ({ok, 0}, increment_counter (my_prog1, wrapctr, [], -3)),
+         ?assertEqual ({ok, ?MD_STATS_MIN_METRIC_VALUE}, increment_counter (my_prog1, wrapctr, [], ?MD_STATS_MIN_METRIC_VALUE)),
+         ?assertEqual ({ok, 0}, increment_counter (my_prog1, wrapctr, [], -1)),
          % always wrap to zero
-         ?assertEqual ({ok, ?MD_STATS_MIN_METRIC_VALUE}, increment (my_prog1, wrapctr, ?MD_STATS_MIN_METRIC_VALUE)),
-         ?assertEqual ({ok, 0}, increment (my_prog1, wrapctr, -10)),
-         ?assertEqual (true, remove_counter (my_prog1, wrapctr))
+         ?assertEqual ({ok, ?MD_STATS_MIN_METRIC_VALUE}, increment_counter (my_prog1, wrapctr, [], ?MD_STATS_MIN_METRIC_VALUE)),
+         ?assertEqual ({ok, 0}, increment_counter (my_prog1, wrapctr, [], -10)),
+         ?assertEqual (true, remove_counter (my_prog1, wrapctr, []))
        end
       },
 
       % tests using create_gauge first
-      ?_assertEqual (undefined, fetch_gauge (my_prog1, my_metric1)),
-      ?_assertEqual (ok, create_gauge (my_prog1, my_metric1)),
-      ?_assertEqual ({error, already_created}, create_gauge (my_prog1, my_metric1)),
-      ?_assertEqual (0, fetch_gauge (my_prog1, my_metric1)),
-      ?_assertEqual (ok, set (my_prog1, my_metric1, 5)),
-      ?_assertEqual (5, fetch_gauge (my_prog1, my_metric1)),
-      ?_assertEqual (ok, set (my_prog1, my_metric1, 6)),
-      ?_assertEqual (ok, set (my_prog1, my_metric1, 4)),
-      ?_assertEqual (4, fetch_gauge (my_prog1, my_metric1)),
-      ?_assertEqual (true, remove_gauge (my_prog1, my_metric1)),
-      ?_assertEqual (undefined, fetch_gauge (my_prog1, my_metric1)),
+      ?_assertEqual (undefined, fetch_gauge (my_prog1, my_metric1,[])),
+      ?_assertEqual (ok, create_gauge (my_prog1, my_metric1,[],"",0)),
+      ?_assertEqual ({error, already_created}, create_gauge (my_prog1, my_metric1,[],"",0)),
+      ?_assertEqual (0, fetch_gauge (my_prog1, my_metric1,[])),
+      ?_assertEqual (ok, set_gauge (my_prog1, my_metric1, [], 5)),
+      ?_assertEqual (5, fetch_gauge (my_prog1, my_metric1,[])),
+      ?_assertEqual (ok, set_gauge (my_prog1, my_metric1,[],6)),
+      ?_assertEqual (ok, set_gauge (my_prog1, my_metric1,[],4)),
+      ?_assertEqual (4, fetch_gauge (my_prog1, my_metric1,[])),
+      ?_assertEqual (true, remove_gauge (my_prog1, my_metric1,[])),
+      ?_assertEqual (undefined, fetch_gauge (my_prog1, my_metric1,[])),
 
       {"gcounter",
        fun () ->
          ?assertEqual (#md_metric.key, #md_gcounter.key),
          ?assertEqual (#md_metric.value, #md_gcounter.value),
-         ?assertEqual (undefined, fetch_gcounter(my_prog1, gctr)),
-         ?assertEqual ({ok, 1}, gincrement (my_prog1, gctr, [], 1)),
-         ?assertEqual ({ok, 4}, gincrement (my_prog1, gctr, [], 3)),
-         ?assertEqual (0, fetch_gcounter(my_prog1, gctr)),
+         ?assertEqual (undefined, fetch_gcounter(my_prog1, gctr,[])),
+         ?assertEqual ({ok, 1}, increment_gcounter (my_prog1, gctr, [], 1)),
+         ?assertEqual ({ok, 4}, increment_gcounter (my_prog1, gctr, [], 3)),
+         ?assertEqual (0, fetch_gcounter(my_prog1, gctr,[])),
          Key = calculate_key(my_prog1, [], gcounter, gctr),
          finalize_metric(Key, ?STATS_TABLE),
          ?assertMatch (V when is_number(V) andalso V >= 4,
-                       fetch_gcounter(my_prog1, gctr)),
+                       fetch_gcounter(my_prog1, gctr,[])),
          ?assertMatch (#md_metric{type = gauge, value = V} when is_number(V) andalso V >= 4,
                        lookup_metric(Key, ?STATS_TABLE)),
-         %% No gincrement in period => rate == 0.
+         %% No increment_gcounter in period => rate == 0.
          finalize_metric(Key, ?STATS_TABLE),
-         ?assertEqual (0, fetch_gcounter(my_prog1, gctr)),
+         ?assertEqual (0, fetch_gcounter(my_prog1, gctr,[])),
          %% Test that rate is not negative when counter wraps.
-         gincrement (my_prog1, gctr, [], ?MD_STATS_MAX_METRIC_VALUE - 80),
+         increment_gcounter (my_prog1, gctr, [], ?MD_STATS_MAX_METRIC_VALUE - 80),
          finalize_metric(Key, ?STATS_TABLE),
-         gincrement (my_prog1, gctr, [], 150),
+         increment_gcounter (my_prog1, gctr, [], 150),
          finalize_metric(Key, ?STATS_TABLE),
          ?assertMatch (V when is_number(V) andalso V > 0,
-                      fetch_gcounter(my_prog1, gctr))
+                      fetch_gcounter(my_prog1, gctr,[]))
        end
       },
 
       % tests using sample sets
-      ?_assertEqual (undefined, fetch_sample_set (my_prog1, my_metric1)),
+      ?_assertEqual (undefined, fetch_sample_set (my_prog1, my_metric1,[])),
       % default size is 10
-      ?_assertEqual (ok, create_sample_set (my_prog1, my_metric1)),
+      ?_assertEqual (ok, create_sample_set (my_prog1, my_metric1,[],"",
+                                           mondemand_config:default_max_sample_size(),
+                                           mondemand_config:default_stats())),
       % add some
       fun () ->
         [
-          ?assertEqual (true, add_sample (my_prog1, my_metric1, N))
+          ?assertEqual (true, add_sample (my_prog1, my_metric1, [], N))
           || N <- lists:seq (1, 5)
         ]
       end,
       % check their values
       fun () ->
-        SS = fetch_sample_set (my_prog1, my_metric1),
+        SS = fetch_sample_set (my_prog1, my_metric1, []),
         ?assertEqual (5, mondemand_statsmsg:get_statset (count, SS)),
         ?assertEqual (15, mondemand_statsmsg:get_statset (sum, SS)),
         ?assertEqual (1, mondemand_statsmsg:get_statset (min, SS)),
@@ -1210,12 +1160,12 @@ config_perf_test_ () ->
       % add a few more
       fun () ->
         [
-          ?assertEqual (true, add_sample (my_prog1, my_metric1, N))
+          ?assertEqual (true, add_sample (my_prog1, my_metric1,[], N))
           || N <- lists:seq (6, 20)
         ]
       end,
       fun () ->
-        SS = fetch_sample_set (my_prog1, my_metric1),
+        SS = fetch_sample_set (my_prog1, my_metric1,[]),
         ?assertEqual (20, mondemand_statsmsg:get_statset (count, SS)),
         ?assertEqual (lists:sum(lists:seq(1,20)),
                       mondemand_statsmsg:get_statset (sum, SS)),
@@ -1227,7 +1177,7 @@ config_perf_test_ () ->
         Max = mondemand_statsmsg:get_statset (max, SS),
         ?assertEqual (true, Max > 1)
       end,
-      ?_assertEqual (true, remove_sample_set (my_prog1, my_metric1)),
+      ?_assertEqual (true, remove_sample_set (my_prog1, my_metric1,[])),
       fun () ->
         ok = create_sample_set(foo,bar,[],"",100, all_sample_set_stats()),
         SS = fetch_sample_set(foo,bar,[]),
@@ -1237,13 +1187,13 @@ config_perf_test_ () ->
         % turns out there was a bug with median when there was only one
         % element in the set, so add one, then check the values are as
         % we expect
-        mondemand_statdb:add_sample(foo,bar,[],10),
+        add_sample(foo,bar,[],10),
         SS1 = fetch_sample_set(foo,bar,[]),
         [ ?assertEqual (10, mondemand_statsmsg:get_statset (S, SS1))
           || S <- all_sample_set_stats (), S =/= count, S =/= median ],
         ?assertEqual (1, mondemand_statsmsg:get_statset (count, SS1)),
         ?assertEqual (0, mondemand_statsmsg:get_statset (median, SS1)),
-        mondemand_statdb:remove_sample_set(foo,bar,[]),
+        remove_sample_set(foo,bar,[]),
 
         % then for completeness just check that all the values are what
         % we would expect for 100 samples
@@ -1261,7 +1211,7 @@ config_perf_test_ () ->
         ?assertEqual (95,mondemand_statsmsg:get_statset (pctl_95, SS2)),
         ?assertEqual (98,mondemand_statsmsg:get_statset (pctl_98, SS2)),
         ?assertEqual (99,mondemand_statsmsg:get_statset (pctl_99, SS2)),
-        mondemand_statdb:remove_sample_set(foo,bar,[])
+        remove_sample_set(foo,bar,[])
       end
     ]
   }.

--- a/src/mondemand_sup.erl
+++ b/src/mondemand_sup.erl
@@ -37,8 +37,29 @@ init([]) ->
         []
     end,
 
+  {ok, Cwd} = file:get_cwd(),
+  HTTPDChild =
+    case mondemand_config:httpd_enabled() of
+      true ->
+        [{mondemand_httpd,
+          {inets, start,
+           [httpd,
+             [{port, mondemand_config:httpd_port()},
+              {bind_address, mondemand_config:httpd_address()},
+              {server_name,"md"},
+              {server_root, Cwd},
+              {document_root, Cwd},
+              {modules, [mondemand_httpd]}
+             ]
+           ]
+          }, permanent, 5000, worker, [mondemand_httpd]
+         }
+        ];
+      false -> []
+    end,
+
   ServiceChildren =
-    VMStatsChild ++
+    VMStatsChild ++ HTTPDChild ++
     [
       { mondemand_statdb,
         {mondemand_statdb, start_link, []},

--- a/src/mondemand_util.erl
+++ b/src/mondemand_util.erl
@@ -22,7 +22,8 @@
            stringify/2,
            integerify/1,
            floatify/1,
-           join/2
+           join/2,
+           first_defined/1
          ]).
 %% Time functions
 -export ([
@@ -307,6 +308,16 @@ join ([H|T], S, []) ->
   join (T,S,[H]);
 join ([H|T], S, A) ->
   join (T,S,[H,S|A]).
+
+first_defined(L) when is_list(L) ->
+  first_defined0(L).
+
+first_defined0([undefined|R]) ->
+  first_defined0(R);
+first_defined0([D|_]) ->
+  D;
+first_defined0([]) ->
+  undefined.
 
 normalize_ip (undefined) -> undefined;
 normalize_ip (IP = {_,_,_,_}) ->

--- a/src/mondemand_util.erl
+++ b/src/mondemand_util.erl
@@ -16,8 +16,10 @@
 -export ([ find_in_dict/2,
            find_in_dict/3,
            binaryify/1,
+           binaryify/2,
            binaryify_context/1,
            stringify/1,
+           stringify/2,
            integerify/1,
            floatify/1,
            join/2
@@ -222,6 +224,11 @@ millis_to_next_round_minute (Ts) ->
   MillisSinceEpoch = now_to_epoch_millis (Ts),
   NextMinuteSinceEpochAsMillis - MillisSinceEpoch.
 
+binaryify (undefined, Default) when is_binary(Default) ->
+  Default;
+binaryify (B, _) ->
+  binaryify (B).
+
 binaryify (B) when is_binary (B) ->
   B;
 binaryify (O) ->
@@ -229,6 +236,11 @@ binaryify (O) ->
 
 binaryify_context (Context) ->
   [ {binaryify (K), binaryify (V)} || {K,V} <- Context].
+
+stringify (undefined, Default) when is_list(Default) ->
+  Default;
+stringify (V, _) ->
+  stringify(V).
 
 stringify (I) when is_integer (I) ->
   integer_to_list (I);


### PR DESCRIPTION
If configured this will start an inets httpd server which can be scraped by prometheus.
In the process of working on this many functions were elevated from the mondemand_statdb module up to the mondemand module so that full CRUD operations could be done using just the mondemand module.  While I've tested locally, this has not been added to any components or tested with large amounts of metrics.
A few things still remain which is why this is WIP
1. any metrics sent via ```mondemand:send_stats/3``` will currently not be available for export.  I'm thinking of caching the previous result and exporting those.
2. flushing to a valid lwes channel is still required.  This just needs a bit of unwinding and rearranging to get going
To try this out, I've been doing the following
```shell
% ./mondemand-dev
```
then paste in
```erlang
mondemand:create_counter(foo, baz, [{another, thing}], "A Baz counter for Foo").
mondemand:create_counter(foo, bob, "A BOB counter for Foo").
mondemand:create_gcounter(foo, rate, "A rate gcounter for Foo").
mondemand:create_gauge(foo, blah, "A blah gauge for Foo").
mondemand:create_sample_set(foo, bar,[{other,thing}], "A Bar counter for Foo", 1000, all).
spawn(fun() ->
        [ begin
            [ begin
                S = rand:uniform(100),
                mondemand:add_sample(foo, bar, [{other,thing}], S)
              end || _ <- lists:seq(1,100+rand:uniform(100)) ],
            [ begin
                C = rand:uniform(100),
                mondemand:increment(foo,baz,[{another,thing}],C),
                mondemand:increment(foo,bob,rand:uniform(5)),
                mondemand:gincrement(foo,rate,rand:uniform(10))
              end || _ <- lists:seq(1,1+rand:uniform(10)) ],
            mondemand:set(foo,blah,rand:uniform(1000)),
            io:format("Added stats, sleeping...~n",[]),
            timer:sleep(60000)
          end || _ <- lists:seq(1,1440)
        ]
       end).
```
If you have prometheus locally you can add the following to your ```prometheus.yml```
```yaml
  - job_name: 'mondemand'

    scrape_interval: 60s
    metrics_path: '/md/metrics'

    static_configs:
    - targets: ['localhost:8082']
      labels:
        group: 'production'
```
The output of the above is
```text
# TYPE foo_bar summary
# HELP foo_bar A Bar counter for Foo
foo_bar{other="thing",quantile="0.5"} 51 1562016900000
foo_bar{other="thing",quantile="0.75"} 77 1562016900000
foo_bar{other="thing",quantile="0.90"} 88 1562016900000
foo_bar{other="thing",quantile="0.95"} 95 1562016900000
foo_bar{other="thing",quantile="0.98"} 98 1562016900000
foo_bar{other="thing",quantile="0.99"} 99 1562016900000
foo_bar{other="thing",quantile="1.0"} 99 1562016900000
foo_bar_sum{other="thing"} 9904 1562016900000
foo_bar_count{other="thing"} 193 1562016900000
# TYPE foo_rate gauge
# HELP foo_rate A rate gcounter for Foo
foo_rate 0
# TYPE foo_blah gauge
# HELP foo_blah A blah gauge for Foo
foo_blah 561
# TYPE mondemand_erlang_flush_total_millis_total counter
# HELP mondemand_erlang_flush_total_millis_total The total amount of time in milliseconds taken to flush
mondemand_erlang_flush_total_millis_total 5
# TYPE mondemand_erlang_flush_count_total counter
# HELP mondemand_erlang_flush_count_total The total number of times events have been flushed
mondemand_erlang_flush_count_total 1
# TYPE foo_baz_total counter
# HELP foo_baz_total A Baz counter for Foo
foo_baz_total{another="thing"} 336
# TYPE foo_bob_total counter
# HELP foo_bob_total A BOB counter for Foo
foo_bob_total 36
```